### PR TITLE
Update jekyll.yml

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
```
Breaking changes
Ubuntu 24.04 is ready to be the default version for the "ubuntu-latest" label in GitHub Actions and Azure DevOps.

Target date
This change will be rolled out over a period of several weeks beginning in September 25th, 2024. We plan to complete the migration by October 30th , 2024.

The motivation for the changes
GitHub Actions and Azure DevOps have supported Ubuntu 24.04 in preview mode since May 2024, and starting from July 2024 Ubuntu 24.04 is generally available for all customers. We have monitored customer feedback to improve the Ubuntu 24.04 image stability and now we are ready to set it as the latest.

Platforms affected

 Azure DevOps
 GitHub Actions
Mitigation ways
Steps or options for impact mitigation
If you see any issues with your workflows during transition period:

Switch back to Ubuntu 22 by changing workflow YAML to use runs-on: ubuntu-22.04 We support two latest LTS Ubuntu versions, so Ubuntu 22 will still be available in near future.
File an issue in this repository
```


I followed the above advice and fixed YAML to use ubuntu-22.04.